### PR TITLE
plugin/forward: added option `failfast_all_unhealthy_upstreams` to re…

### DIFF
--- a/plugin/forward/README.md
+++ b/plugin/forward/README.md
@@ -51,6 +51,7 @@ forward FROM TO... {
     health_check DURATION [no_rec] [domain FQDN]
     max_concurrent MAX
     next RCODE_1 [RCODE_2] [RCODE_3...]
+    failfast_all_unhealthy_upstreams
 }
 ~~~
 
@@ -97,6 +98,7 @@ forward FROM TO... {
   at least greater than the expected *upstream query rate* * *latency* of the upstream servers.
   As an upper bound for **MAX**, consider that each concurrent query will use about 2kb of memory.
 * `next` If the `RCODE` (i.e. `NXDOMAIN`) is returned by the remote then execute the next plugin. If no next plugin is defined, or the next plugin is not a `forward` plugin, this setting is ignored
+* `failfast_all_unhealthy_upstreams` - determines the handling of requests when all upstream servers are unhealthy and unresponsive to health checks. Enabling this option will immediately return SERVFAIL responses for all requests. By default, requests are sent to a random upstream.
 
 Also note the TLS config is "global" for the whole forwarding proxy if you need a different
 `tls_servername` for different upstreams you're out of luck.

--- a/plugin/forward/health_test.go
+++ b/plugin/forward/health_test.go
@@ -277,3 +277,79 @@ func TestHealthDomain(t *testing.T) {
 		t.Errorf("Expected number of health checks with Domain==%s to be %d, got %d", hcDomain, 1, i1)
 	}
 }
+
+func TestAllUpstreamsDown(t *testing.T) {
+	qs := uint32(0)
+	s := dnstest.NewServer(func(w dns.ResponseWriter, r *dns.Msg) {
+		// count non-healthcheck queries
+		if r.Question[0].Name != "." {
+			atomic.AddUint32(&qs, 1)
+		}
+		// timeout
+	})
+	defer s.Close()
+
+	s1 := dnstest.NewServer(func(w dns.ResponseWriter, r *dns.Msg) {
+		// count non-healthcheck queries
+		if r.Question[0].Name != "." {
+			atomic.AddUint32(&qs, 1)
+		}
+		// timeout
+	})
+	defer s1.Close()
+
+	p := proxy.NewProxy("TestHealthAllUpstreamsDown", s.Addr, transport.DNS)
+	p1 := proxy.NewProxy("TestHealthAllUpstreamsDown2", s1.Addr, transport.DNS)
+	p.GetHealthchecker().SetReadTimeout(10 * time.Millisecond)
+	p1.GetHealthchecker().SetReadTimeout(10 * time.Millisecond)
+
+	f := New()
+	f.SetProxy(p)
+	f.SetProxy(p1)
+	f.failfastUnhealthyUpstreams = true
+	f.maxfails = 1
+	// Make proxys fail by checking health twice
+	// i.e, fails > maxfails
+	for range f.maxfails + 1 {
+		p.GetHealthchecker().Check(p)
+		p1.GetHealthchecker().Check(p1)
+	}
+
+	defer f.OnShutdown()
+
+	// Check if all proxies are down
+	if !p.Down(f.maxfails) || !p1.Down(f.maxfails) {
+		t.Fatalf("Expected all proxies to be down")
+	}
+	req := new(dns.Msg)
+	req.SetQuestion("example.org.", dns.TypeA)
+	resp, err := f.ServeDNS(context.TODO(), &test.ResponseWriter{}, req)
+
+	if resp != dns.RcodeServerFailure {
+		t.Errorf("Expected Response code: %d, Got: %d", dns.RcodeServerFailure, resp)
+	}
+
+	if err != ErrNoHealthy {
+		t.Errorf("Expected error message: no healthy proxies, Got: %s", err.Error())
+	}
+
+	q1 := atomic.LoadUint32(&qs)
+	if q1 != 0 {
+		t.Errorf("Expected queries to the upstream: 0, Got: %d", q1)
+	}
+
+	// set failfast to false to check if queries get answered
+	f.failfastUnhealthyUpstreams = false
+
+	req = new(dns.Msg)
+	req.SetQuestion("example.org.", dns.TypeA)
+	_, err = f.ServeDNS(context.TODO(), &test.ResponseWriter{}, req)
+	if err == ErrNoHealthy {
+		t.Error("Unexpected error message: no healthy proxies")
+	}
+
+	q1 = atomic.LoadUint32(&qs)
+	if q1 != 1 {
+		t.Errorf("Expected queries to the upstream: 1, Got: %d", q1)
+	}
+}

--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -306,6 +306,12 @@ func parseBlock(c *caddy.Controller, f *Forward) error {
 
 			f.nextAlternateRcodes = append(f.nextAlternateRcodes, rc)
 		}
+	case "failfast_all_unhealthy_upstreams":
+		args := c.RemainingArgs()
+		if len(args) != 0 {
+			return c.ArgErr()
+		}
+		f.failfastUnhealthyUpstreams = true
 	default:
 		return c.Errf("unknown property '%s'", c.Val())
 	}


### PR DESCRIPTION
…turn servfail if all upstreams are down (#6999)

* feat: option to return servfail if upstreams are down



* fix based on review comments and added to Readme



* add tests to improve code coverage



* added failfast_all_unhealthy_upstreams option to forward plugin



---------

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
